### PR TITLE
Add etirelli to opendatahub-operator and opendatahub-community maintainers

### DIFF
--- a/.github/build/Containerfile
+++ b/.github/build/Containerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9/python-311:1-7.1684740557
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+COPY main.py /tmp/main.py

--- a/.github/build/Pipfile
+++ b/.github/build/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.11"

--- a/.github/build/main.py
+++ b/.github/build/main.py
@@ -51,7 +51,11 @@ def get_affected_groups(old_org, new_org):
 def get_valid_approvers(org: dict, groups: dict):
     approvers = []
     for team in groups["teams"]:
-        approvers.append((team, set(org.get("teams").get(team).get("maintainers"))))
+        maintainers = org.get("teams").get(team).get("maintainers")
+        if maintainers:
+            approvers.append((team, set(maintainers)))
+        else:
+            print(f"{team} does not have a maintainers defined.")
     if groups["org_changed"]:
         approvers.append((org.get("name"), set(org.get("admins"))))
     return approvers

--- a/.github/build/main.py
+++ b/.github/build/main.py
@@ -1,0 +1,85 @@
+import yaml
+import os
+import requests
+
+def main():
+    with open("./config/opendatahub-io/org.yaml", "r") as f:
+        data = yaml.load(f, Loader=yaml.FullLoader)
+        new_odh_org = data.get("orgs").get("opendatahub-io")
+    os.system("git fetch --all")
+    os.system("git checkout main")
+
+    with open("./config/opendatahub-io/org.yaml", "r") as f:
+        data = yaml.load(f, Loader=yaml.FullLoader)
+        old_odh_org = data.get("orgs").get("opendatahub-io")
+
+    pr_number = os.environ.get("PR_NUMBER")
+    affected_teams = get_affected_groups(old_odh_org, new_odh_org)
+    approver_teams = get_valid_approvers(old_odh_org, affected_teams)
+    pr_approvers = get_pr_approvers(pr_number, os.environ.get("TOKEN"))
+    for team in approver_teams:
+        if team[1].intersection(pr_approvers):
+            print(f"Valid reviewer found for {team[0]} in PR approvers: {pr_approvers}")
+        else:
+            print(f"No valid reviewers found for {team[0]} in PR approvers: {pr_approvers}")
+            exit(1)
+
+
+def get_affected_groups(old_org, new_org):
+    affected_groups = {"teams": [], "org_changed": False}
+    if old_org==new_org:
+        print("No changes detected to org yaml")
+        exit(0)
+    old_org_teams = old_org.get("teams")
+    new_org_teams = new_org.get("teams")
+    for team in old_org_teams:
+        if old_org_teams.get(team) != new_org_teams.get(team):
+            print(f"{team} has been changed")
+            affected_groups["teams"].append(team)
+    for key, value in old_org.items():
+        if key != "teams":
+            if value != new_org.get(key):
+                affected_groups["org_changed"] = True
+                break
+    return affected_groups
+
+
+def get_valid_approvers(org: dict, groups: dict):
+    approvers = []
+    for team in groups["teams"]:
+        approvers.append((team, set(org.get("teams").get(team).get("maintainers"))))
+    if groups["org_changed"]:
+        approvers.append((org.get("name"), set(org.get("admins"))))
+    return approvers
+
+
+def get_pr_approvers(id: int, token: str):
+    response = requests.get(
+        "https://api.github.com/repos/" + os.environ.get("REPO") + "/pulls/" + id + "/reviews",
+        headers={
+        "Authorization": "Bearer " + token
+        }
+    )
+
+    # Check the response status code
+    if response.status_code == 200:
+        # Get the list of review comments from the response
+        reviews = response.json()
+
+        # Create a list of users who have approved the PR
+        approved_users = set()
+        for review in reviews:
+            if review['state'] == "CHANGES_REQUESTED":
+                print(f"{review['user']['login']} has requested changes.")
+                exit(1)
+            if review['state'] == "APPROVED":
+                approved_users.add(review['user']['login'])
+
+        return approved_users
+    else:
+        print(f"Received an invalid response code: {response.status_code}")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/build/main.py
+++ b/.github/build/main.py
@@ -17,12 +17,16 @@ def main():
     affected_teams = get_affected_groups(old_odh_org, new_odh_org)
     approver_teams = get_valid_approvers(old_odh_org, affected_teams)
     pr_approvers = get_pr_approvers(pr_number, os.environ.get("TOKEN"))
+
+    approved = True
     for team in approver_teams:
         if team[1].intersection(pr_approvers):
-            print(f"Valid reviewer found for {team[0]} in PR approvers: {pr_approvers}")
+            print(f"Valid reviewer found for {team[0]} in PR approvers.")
         else:
-            print(f"No valid reviewers found for {team[0]} in PR approvers: {pr_approvers}")
-            exit(1)
+            print(f"No valid reviewers found for {team[0]} in PR approvers. Request approval from one of the following: {team[1]}")
+            approved = False
+    if not approved:
+        exit(1)
 
 
 def get_affected_groups(old_org, new_org):

--- a/.github/build/requirements.txt
+++ b/.github/build/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2023.5.7
+charset-normalizer==3.1.0
+idna==3.4
+PyYAML==6.0
+requests==2.31.0
+smmap==5.0.0
+urllib3==2.0.2

--- a/.github/workflows/approval_check.yml
+++ b/.github/workflows/approval_check.yml
@@ -6,9 +6,9 @@ jobs:
   check-membership-approvals:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/opendatahub/org-management-checker:v0.0.1
+      image: quay.io/opendatahub/org-management-checker:v0.0.2
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run PR validation
         run: python3 /tmp/main.py
         env:

--- a/.github/workflows/approval_check.yml
+++ b/.github/workflows/approval_check.yml
@@ -1,0 +1,17 @@
+name: Check Membership Pull Request
+on:
+  pull_request:
+  pull_request_review:
+jobs:
+  check-membership-approvals:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/opendatahub/org-management-checker:v0.0.1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run PR validation
+        run: python3 /tmp/main.py
+        env:
+          TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_NUMBER: ${{github.event.pull_request.number}}
+          REPO: ${{github.repository}}

--- a/.github/workflows/approval_check.yml
+++ b/.github/workflows/approval_check.yml
@@ -6,7 +6,7 @@ jobs:
   check-membership-approvals:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/opendatahub/org-management-checker:v0.0.3
+      image: quay.io/opendatahub/org-management-checker:v0.0.4
     steps:
       - uses: actions/checkout@v3
       - name: Run PR validation

--- a/.github/workflows/approval_check.yml
+++ b/.github/workflows/approval_check.yml
@@ -6,7 +6,7 @@ jobs:
   check-membership-approvals:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/opendatahub/org-management-checker:v0.0.2
+      image: quay.io/opendatahub/org-management-checker:v0.0.3
     steps:
       - uses: actions/checkout@v3
       - name: Run PR validation

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -88,6 +88,7 @@ orgs:
     - aslakknutsen
     - yannnz
     - yih-wang
+    - vaibhavjainwiz
     members_can_create_repositories: false
     name: Open Data Hub
     teams:
@@ -194,6 +195,7 @@ orgs:
         - lugi0
         - maroroman
         - rimolive
+        - vaibhavjainwiz
         privacy: closed
         repos:
           modelmesh: write
@@ -227,6 +229,7 @@ orgs:
         - lugi0
         - maroroman
         - rimolive
+        - vaibhavjainwiz
         privacy: closed
         repos:
           modelmesh-runtime-adapter: write
@@ -260,6 +263,7 @@ orgs:
         - lugi0
         - maroroman
         - rimolive
+        - vaibhavjainwiz
         privacy: closed
         repos:
           modelmesh-serving: write
@@ -293,6 +297,7 @@ orgs:
         - lugi0
         - maroroman
         - rimolive
+        - vaibhavjainwiz
         privacy: closed
         repos:
           rest-proxy: write
@@ -326,6 +331,7 @@ orgs:
         - lugi0
         - maroroman
         - rimolive
+        - vaibhavjainwiz
         privacy: closed
         repos:
           odh-model-controller: write

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -163,10 +163,10 @@ orgs:
         - sutaakar
         - tedhtchang
         - VanillaSpoon
-
         privacy: closed
         repos:
           distributed-workloads: maintain
+          kuberay: maintain
       Elyra Maintainers:
         description: Maintainers of the Elyra AI notebook and build pipelines
         maintainers:

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -17,6 +17,7 @@ orgs:
     - 4n4nd
     - akchinSTC
     - alexcreasy
+    - amadhusu
     - amsharma3  
     - andrewballantyne
     - anishasthana
@@ -131,6 +132,7 @@ orgs:
         - gregsheremeta
         - HumairAK
         members:
+        - amadhusu
         - DharmitD
         - gmfrasca
         - gregsheremeta

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -39,6 +39,7 @@ orgs:
     - etirelli
     - ezidav
     - fcami
+    - Fiona-Waters
     - Gkrumbach07
     - gmfrasca
     - goern
@@ -149,6 +150,7 @@ orgs:
         - carsonmh
         - ChughShilpa
         - dimakis
+        - Fiona-Waters
         - jiripetrlik
         - Maxusmusti
         - KPostOffice

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -410,9 +410,9 @@ orgs:
         maintainers:
         - cfchase
         - LaVLaS
+        - andrewballantyne
         members:
         - alexcreasy
-        - andrewballantyne
         - Gkrumbach07
         - lucferbux
         - DaoDaoNoCode

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -82,6 +82,7 @@ orgs:
     - tedhtchang
     - tteofili
     - VaishnaviHire
+    - VanillaSpoon
     - VannTen
     - vconzola
     - VedantMahabaleshwarkar
@@ -157,6 +158,7 @@ orgs:
         - Srihari1192
         - sutaakar
         - tedhtchang
+        - VanillaSpoon
 
         privacy: closed
         repos:

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -126,18 +126,20 @@ orgs:
         repos:
           odh-manifests: triage
       Data Science Pipelines Maintainers:
-        description: ""
+        description: "Maintainers for ODH DSP and related repos."
         maintainers:
         - gregsheremeta
-        members:
-        - rimolive
         - HumairAK
-        - harshad16
-        - gmfrasca
+        members:
         - DharmitD
+        - gmfrasca
+        - gregsheremeta
+        - HumairAK
+        - rimolive
         privacy: closed
         repos:
-          data-science-pipelines-operator: maintain
+          data-science-pipelines-operator: admin
+          data-science-pipelines: admin
       Distributed Workloads Maintainers:
         description: ""
         maintainers:
@@ -344,39 +346,6 @@ orgs:
         privacy: closed
         repos:
           odh-model-controller: write
-      data-science-pipelines repository Write:
-        description: "Members with Write access to the data-science-pipelines repository"
-        members:
-        - DaoDaoNoCode
-        - DharmitD
-        - HumairAK
-        - Jooho
-        - VaishnaviHire
-        - VannTen
-        - Xaenalt
-        - andrewballantyne
-        - atheo89
-        - dchourasia
-        - dfeddema
-        - dibryant
-        - durandom
-        - gmfrasca
-        - goern
-        - guimou
-        - harshad16
-        - heyselbi
-        - jedemo
-        - jeff-phillips-18
-        - jgarciao
-        - judyobrienie
-        - kywalker-rh
-        - lucferbux
-        - lugi0
-        - maroroman
-        - rimolive
-        privacy: closed
-        repos:
-          data-science-pipelines: write
       Notebook Controller Maintainers:
         description: Maintainers of the notebook controller and all connected repos
         maintainers:

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -62,6 +62,7 @@ orgs:
     - kywalker-rh
     - lucferbux
     - lugi0
+    - manaswinidas
     - maroroman
     - Maxusmusti
     - MichaelClifford
@@ -414,6 +415,7 @@ orgs:
         - Gkrumbach07
         - lucferbux
         - DaoDaoNoCode
+        - manaswinidas
         privacy: closed
         repos:
           odh-dashboard: maintain

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -146,9 +146,9 @@ orgs:
         description: ""
         maintainers:
         - accorvin
-        members:
-        - amsharma3  
         - anishasthana
+        members:
+        - amsharma3
         - astefanutti
         - Bobbins228
         - carsonmh

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -67,6 +67,7 @@ orgs:
     - Maxusmusti
     - MichaelClifford
     - mlassak
+    - pnaik1
     - r00ta
     - rimolive
     - RobGeada
@@ -416,6 +417,7 @@ orgs:
         - lucferbux
         - DaoDaoNoCode
         - manaswinidas
+        - pnaik1
         privacy: closed
         repos:
           odh-dashboard: maintain

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -35,6 +35,7 @@ orgs:
     - dimakis
     - durandom
     - erwangranger
+    - etirelli
     - ezidav
     - fcami
     - Gkrumbach07

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -22,6 +22,7 @@ orgs:
     - anishasthana
     - astefanutti
     - atheo89
+    - Bobbins228
     - carsonmh
     - chtyler
     - ChughShilpa
@@ -144,6 +145,7 @@ orgs:
         - amsharma3  
         - anishasthana
         - astefanutti
+        - Bobbins228
         - carsonmh
         - ChughShilpa
         - dimakis

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -147,13 +147,13 @@ orgs:
         maintainers:
         - accorvin
         - anishasthana
+        - dimakis
         members:
         - amsharma3
         - astefanutti
         - Bobbins228
         - carsonmh
         - ChughShilpa
-        - dimakis
         - Fiona-Waters
         - jiripetrlik
         - KPostOffice

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -147,7 +147,6 @@ orgs:
         maintainers:
         - accorvin
         members:
-        - MichaelClifford
         - amsharma3  
         - anishasthana
         - astefanutti
@@ -157,8 +156,9 @@ orgs:
         - dimakis
         - Fiona-Waters
         - jiripetrlik
-        - Maxusmusti
         - KPostOffice
+        - Maxusmusti
+        - MichaelClifford
         - Srihari1192
         - sutaakar
         - tedhtchang

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -435,6 +435,7 @@ orgs:
       ODH Operator Maintainers:
         description: Maintainers of the ODH Operator repo
         maintainers:
+        - etirelli
         - LaVLaS
         - VaishnaviHire
         privacy: closed
@@ -443,6 +444,7 @@ orgs:
       ODH Community Maintainers:
         description: Maintainers of the ODH Community repo
         maintainers:
+          - etirelli
           - jkoehler-redhat
           - LaVLaS
         members:


### PR DESCRIPTION
Add etirelli to opendatahub-operator and opendatahub-community maintainers

## New Open Data Hub Member Requirements
- [X] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [X] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [X] New members are added in alphabetical order
- [X] Only one new member change per commit (if you add two members separate it in two commits
- [X] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
